### PR TITLE
Export maps

### DIFF
--- a/tests/package-h/package.json
+++ b/tests/package-h/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "package-h",
+  "version": "1.0.0",
+  "license": "MIT",
+  "exports": {
+    "./foo": {
+      "types": "./lib/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
+  "dependencies": {
+    "typescript": "*"
+  }
+}

--- a/tests/package-h/src/index.ts
+++ b/tests/package-h/src/index.ts
@@ -1,0 +1,1 @@
+export const PackageH: string = "foo module for package H";

--- a/tests/package-h/tsconfig.json
+++ b/tests/package-h/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "module": "esnext"
+      
+  }
+}

--- a/tests/test-webpack-alias/src/index.ts
+++ b/tests/test-webpack-alias/src/index.ts
@@ -42,3 +42,7 @@ console.log(PackageG_default);
 // import from outDir, project with rootDir=src and outDir=lib, and tsconfig in a subpackage
 import { PackageG_moduleG } from "package-g/sources/lib/module-g";
 console.log(PackageG_moduleG);
+
+// import from a package with export maps
+import { PackageH } from "package-h/foo";
+console.log(PackageH);

--- a/tests/test-webpack-alias/tsconfig.json
+++ b/tests/test-webpack-alias/tsconfig.json
@@ -2,7 +2,10 @@
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+      "outDir": "./lib",
+      "target": "esnext",
+      "module": "esnext",
+      "moduleResolution": "bundler"
   },
   "references": [
     { "path": "../package-a" },
@@ -10,6 +13,7 @@
     { "path": "../package-c/tsconfig.prod.json" },
     { "path": "../package-d" },
     { "path": "../package-e" },
-    { "path": "../package-g/sources" }
+    { "path": "../package-g/sources" },
+    { "path": "../package-h" }
   ]
 }

--- a/tests/test-webpack-alias/webpack.config.js
+++ b/tests/test-webpack-alias/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   resolve: {
     extensions: [".ts"],
+    conditionNames: ["source", "import", "require"],  
     alias: getAliasForProject()
   },
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,9 +932,9 @@ tslib@^1.9.0:
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 typescript@*:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
webpack-project-references-alias does not work with packages having a `package.json#exports` field.
Since the exports map feature offers a better way to setup project reference redirect than webpack-project-references-alias, we choose to lean on custom conditions of exports maps instead.